### PR TITLE
enhance search functionality to support prefix matching for pipeline …

### DIFF
--- a/lib/MongoDB/Jobs.js
+++ b/lib/MongoDB/Jobs.js
@@ -223,12 +223,12 @@ class Jobs extends Collection {
         user,
         action = executeActions.RUN,
         tags
-    } = {}) {
+    } = {}, searchByPrefix = false) {
         return new Query()
             .addParam('pipeline.experimentName', experimentName)
-            .addOrParams(['jobId', 'externalId', 'pipeline.name'], pipelineName)
+            .addOrParams(['jobId', 'externalId', 'pipeline.name'], pipelineName, searchByPrefix)
             .addParam('pipeline.types', pipelineType)
-            .addParam('pipeline.nodes.algorithmName', algorithmName)
+            .addParam('pipeline.nodes.algorithmName', algorithmName, searchByPrefix)
             .addParam('status.status', pipelineStatus)
             .addParam('pipeline.options.concurrentPipelines.rejectOnFailure', isConcurrencyReject)
             .addGt('preference', preference)
@@ -248,8 +248,8 @@ class Jobs extends Collection {
         limit,
         fields,
         exists,
-    }) {
-        const queryObj = this._createQuery({ ...query, exists });
+    }, searchByPrefix = false) {
+        const queryObj = this._createQuery({ ...query, exists }, searchByPrefix);
         const response = await super.searchApi({
             query: queryObj,
             cursor,

--- a/lib/MongoDB/Query.js
+++ b/lib/MongoDB/Query.js
@@ -3,19 +3,25 @@ class Query {
         this._map = Object.create(null);
     }
 
-    addParam(key, value) {
+    _buildPrefixRegex(value) {
+        // escape regex special chars to prevent injection
+        const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return { $regex: `^${escaped}` };
+    }
+
+    addParam(key, value, byPrefix = false) {
         if (value !== undefined) {
-            this._map[key] = value;
+            this._map[key] = byPrefix ? this._buildPrefixRegex(value) : value;
         }
         return this;
     }
 
-    addOrParams(keys, value) {
+    addOrParams(keys, value, byPrefix = false) {
         if (value !== undefined) {
             this._map.$or = [];
             keys.forEach(key => {
                 if (key !== undefined) {
-                    this._map.$or.push({ [key]: value });
+                    this._map.$or.push({ [key]: byPrefix ? this._buildPrefixRegex(value) : value });
                 }
             });
         }


### PR DESCRIPTION
Now supports in db to search by prefix, for jobs (pipeline name, job id and algorithm name in job search)
Related issue - https://github.com/kube-HPC/hkube/issues/2286

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/db.hkube/46)
<!-- Reviewable:end -->
