### PR TITLE
implement UserPreferences class with CRUD operations and corresponding tests

### DIFF
--- a/lib/MongoDB/UserPreferences.js
+++ b/lib/MongoDB/UserPreferences.js
@@ -1,0 +1,29 @@
+const Collection = require('./Collection');
+const collections = require('./collections');
+
+class UserPreferences extends Collection {
+    constructor(db, client) {
+        super(db, client, collections.UserPreferences);
+    }
+
+    async fetch({ userId }) {
+        const entry = await super.fetch({ userId }, { excludeId: true });
+        return entry;
+    }
+
+    async replace(doc) {
+        await super.replaceOne({
+            filter: { userId: doc.userId },
+            replacement: doc,
+            upsert: true,
+        });
+        return doc;
+    }
+
+    async delete({ userId }) {
+        const result = await super.delete({ userId });
+        return result;
+    }
+}
+
+module.exports = UserPreferences;

--- a/lib/MongoDB/collections.js
+++ b/lib/MongoDB/collections.js
@@ -235,7 +235,8 @@ const config = {
                 },
             ],
         },
-    },    UserPreferences: {
+    },
+    UserPreferences: {
         name: 'userPreferences',
         entityName: 'userPreference',
         indices: [
@@ -244,7 +245,7 @@ const config = {
                 userId: 'asc',
                 unique: true,
             },
-        ],
+         ], 
     },};
 
 module.exports = config;

--- a/lib/MongoDB/collections.js
+++ b/lib/MongoDB/collections.js
@@ -235,7 +235,16 @@ const config = {
                 },
             ],
         },
-    },
-};
+    },    UserPreferences: {
+        name: 'userPreferences',
+        entityName: 'userPreference',
+        indices: [
+            {
+                indexName: 'userId',
+                userId: 'asc',
+                unique: true,
+            },
+        ],
+    },};
 
 module.exports = config;

--- a/lib/MongoDB/collections.js
+++ b/lib/MongoDB/collections.js
@@ -245,7 +245,7 @@ const config = {
                 userId: 'asc',
                 unique: true,
             },
-         ], 
-    },};
+        ],
+    }, };
 
 module.exports = config;

--- a/lib/MongoDB/index.js
+++ b/lib/MongoDB/index.js
@@ -14,6 +14,7 @@ const WebhookStatus = require('./webhooks/status');
 const WebhookResult = require('./webhooks/result');
 const PipelineDrivers = require('./PipelineDrivers');
 const Snapshots = require('./Snapshots');
+const UserPreferences = require('./UserPreferences');
 
 class MongoDB {
     constructor(config) {
@@ -68,6 +69,7 @@ class MongoDB {
             status: new WebhookStatus(this.db, this.client),
             result: new WebhookResult(this.db, this.client),
         };
+        this.userPreferences = new UserPreferences(this.db, this.client);
         if (createIndices) {
             await this._createIndices();
         }
@@ -88,6 +90,7 @@ class MongoDB {
         await this.triggersTree.init();
         await this.webhooks.status.init();
         await this.webhooks.result.init();
+        await this.userPreferences.init();
     }
 
     get isConnected() {

--- a/tests/common.js
+++ b/tests/common.js
@@ -366,6 +366,18 @@ const generateMockFiles = (amount = 4) =>
         uploadedAt: new Date().getTime(),
     }));
 
+const generateUserPreferences = (overrides = {}) => ({
+    userId: overrides.userId || `device-${uuid()}`,
+    theme: overrides.theme || 'light',
+    scoopIntervalHours: overrides.scoopIntervalHours || 24,
+    tables: overrides.tables || {
+        jobs: { columns: {} },
+        algorithms: { columns: {} },
+        pipelines: { columns: {} },
+    },
+    updatedAt: overrides.updatedAt || new Date().toISOString(),
+});
+
 module.exports = {
     generateAlgorithm,
     generateTask,
@@ -388,5 +400,6 @@ module.exports = {
     generateEntries,
     generateMockFiles,
     generateDevenv,
-    generateAudit
+    generateAudit,
+    generateUserPreferences,
 };

--- a/tests/preferences.test.js
+++ b/tests/preferences.test.js
@@ -1,0 +1,93 @@
+const { expect } = require('chai');
+const { generateUserPreferences } = require('./common');
+let db = null;
+
+describe('UserPreferences', () => {
+    before(async () => {
+        db = global.testParams.db;
+    });
+
+    it('should return null for non-existing userId', async () => {
+        const response = await db.userPreferences.fetch({ userId: 'no-such-user' });
+        expect(response).to.be.null;
+    });
+
+    it('should replace (upsert) and fetch preferences', async () => {
+        const prefs = generateUserPreferences();
+        await db.userPreferences.replace(prefs);
+        const res = await db.userPreferences.fetch({ userId: prefs.userId });
+        expect(res.userId).to.eql(prefs.userId);
+        expect(res.theme).to.eql(prefs.theme);
+        expect(res.scoopIntervalHours).to.eql(prefs.scoopIntervalHours);
+        expect(res.tables).to.eql(prefs.tables);
+    });
+
+    it('should replace existing preferences entirely', async () => {
+        const prefs = generateUserPreferences({ theme: 'dark' });
+        await db.userPreferences.replace(prefs);
+
+        const updated = {
+            ...prefs,
+            theme: 'lightsOut',
+            scoopIntervalHours: 720,
+            tables: {
+                jobs: { columns: { name: { visible: true, width: 200 } } },
+                algorithms: { columns: {} },
+                pipelines: { columns: {} },
+            },
+            updatedAt: new Date().toISOString(),
+        };
+        await db.userPreferences.replace(updated);
+
+        const res = await db.userPreferences.fetch({ userId: prefs.userId });
+        expect(res.theme).to.eql('lightsOut');
+        expect(res.scoopIntervalHours).to.eql(720);
+        expect(res.tables.jobs.columns.name.visible).to.eql(true);
+    });
+
+    it('should delete preferences', async () => {
+        const prefs = generateUserPreferences();
+        await db.userPreferences.replace(prefs);
+        const res = await db.userPreferences.delete({ userId: prefs.userId });
+        expect(res).to.eql({ deleted: 1 });
+        const fetched = await db.userPreferences.fetch({ userId: prefs.userId });
+        expect(fetched).to.be.null;
+    });
+
+    it('should not throw when deleting non-existing preferences', async () => {
+        const res = await db.userPreferences.delete({ userId: 'non-existing-user' });
+        expect(res).to.eql({ deleted: 0 });
+    });
+
+    it('should handle multiple users independently', async () => {
+        const prefs1 = generateUserPreferences({ theme: 'dark' });
+        const prefs2 = generateUserPreferences({ theme: 'light' });
+        await db.userPreferences.replace(prefs1);
+        await db.userPreferences.replace(prefs2);
+
+        const res1 = await db.userPreferences.fetch({ userId: prefs1.userId });
+        const res2 = await db.userPreferences.fetch({ userId: prefs2.userId });
+        expect(res1.theme).to.eql('dark');
+        expect(res2.theme).to.eql('light');
+    });
+
+    it('should store nested table column settings', async () => {
+        const prefs = generateUserPreferences({
+            tables: {
+                jobs: {
+                    columns: {
+                        name: { visible: true, width: 200 },
+                        status: { visible: false, width: 120 },
+                    },
+                },
+                algorithms: { columns: { name: { visible: true, width: 300 } } },
+                pipelines: { columns: {} },
+            },
+        });
+        await db.userPreferences.replace(prefs);
+        const res = await db.userPreferences.fetch({ userId: prefs.userId });
+        expect(res.tables.jobs.columns.name.width).to.eql(200);
+        expect(res.tables.jobs.columns.status.visible).to.eql(false);
+        expect(res.tables.algorithms.columns.name.width).to.eql(300);
+    });
+});


### PR DESCRIPTION
kube-HPC/hkube#2427
## Add UserPreferences DB Layer

### Summary
Adds a new `UserPreferences` collection and class to the DB provider, enabling persistent storage of per-user UI preferences (theme, refresh interval, table column settings, etc.).

### What was added

**New files:**
- UserPreferences.js — New class extending the base `Collection`, exposing three methods:
  - `fetch({ userId })` — Retrieves a user's preferences by `userId` (returns `null` if not found)
  - `replace(doc)` — Upserts the entire preferences document (full replacement, not a partial merge)
  - `delete({ userId })` — Deletes a user's preferences and returns `{ deleted: count }`
- preferences.test.js — Test suite covering all CRUD operations

**Modified files:**
- collections.js — Added `UserPreferences` collection definition with a unique ascending index on `userId`
- index.js — Instantiated `UserPreferences` in `init()` and registered its indices in `_createIndices()`

### Document structure
```js
{
  userId: string,              // unique identifier for the user
  theme: string,               // e.g. 'light', 'dark', 'lightsOut'
  scoopIntervalHours: number,  // data refresh interval in hours
  tables: {                    // per-table column visibility & width settings
    jobs: { columns: { ... } },
    algorithms: { columns: { ... } },
    pipelines: { columns: { ... } }
  },
  updatedAt: string            // ISO 8601 timestamp
}
```

### Design decisions
- **Full document replacement** (`replaceOne` with `upsert: true`) rather than partial updates — the client always sends the complete preferences object, keeping the logic simple and avoiding merge conflicts.
- **Unique index on `userId`** ensures one preferences document per user.
- **MongoDB `_id` excluded** from fetch results to keep responses clean.
- **Safe delete** — deleting a non-existent user does not throw; it simply returns `{ deleted: 0 }`.

### Test coverage (6 tests)
1. Returns `null` for a non-existing user
2. Upsert + fetch round-trip
3. Full replacement on subsequent upserts (verifies old fields are overwritten, not merged)
4. Delete existing user
5. Delete non-existing user without error
6. Multi-user independence with nested table column settings

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/db.hkube/48)
<!-- Reviewable:end -->
